### PR TITLE
Update app title to be more inclusive

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>SplitMate - 夫婦間家計費精算システム</title>
+    <title>SplitMate - 夫婦・カップルの精算アプリ</title>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -264,7 +264,7 @@ const AppContent = () => {
           <div className="flex justify-between items-center py-6">
             <div>
               <h1 className="text-3xl font-bold text-gray-900">SplitMate</h1>
-              <p className="text-gray-600">夫婦間家計費精算システム</p>
+              <p className="text-gray-600">夫婦・カップルの精算アプリ</p>
             </div>
             <UserMenu />
           </div>


### PR DESCRIPTION
This PR updates the app title and description to be more inclusive and user-friendly.

## Changes
- **Title tag**: Change from '夫婦間家計費精算システム' to '夫婦・カップルの精算アプリ'
- **Main page description**: Update the subtitle on the main page
- **Files modified**:
  -  - HTML title tag
  -  - Main page description

## Rationale
The new title '夫婦・カップルの精算アプリ' is:
- More inclusive (includes couples beyond just married couples)
- More user-friendly and approachable
- Shorter and easier to remember
- Better reflects the modern target audience