### PR TITLE
Remove clear form button from ExpenseForm

### DIFF
--- a/frontend/src/components/ExpenseForm.tsx
+++ b/frontend/src/components/ExpenseForm.tsx
@@ -135,17 +135,7 @@ const ExpenseForm = forwardRef<ExpenseFormHandle, ExpenseFormProps>(({ onSubmit,
     saveFormDataToStorage(newData);
   };
 
-  const handleClearForm = () => {
-    const clearedData = {
-      description: '',
-      amount: 0,
-      payerId: 'husband-001',
-      expenseYear: currentYear,
-      expenseMonth: currentMonth
-    };
-    setFormData(clearedData);
-    localStorage.removeItem('splitmate-expense-form');
-  };
+  // フォームをクリア機能を削除
 
   return (
     <div className="card">
@@ -250,22 +240,14 @@ const ExpenseForm = forwardRef<ExpenseFormHandle, ExpenseFormProps>(({ onSubmit,
           </div>
         </div>
 
-        {/* 送信ボタンとクリアボタン */}
-        <div className="space-y-3">
+        {/* 送信ボタン */}
+        <div>
           <button
             type="submit"
             disabled={isLoading || !formData.description || formData.amount <= 0}
             className="btn-primary w-full disabled:opacity-50 disabled:cursor-not-allowed"
           >
             {isLoading ? '送信中...' : '入力完了'}
-          </button>
-          
-          <button
-            type="button"
-            onClick={handleClearForm}
-            className="w-full px-4 py-2 text-sm text-gray-600 bg-gray-100 border border-gray-300 rounded-md hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-offset-2 transition-colors"
-          >
-            フォームをクリア
           </button>
         </div>
       </form>


### PR DESCRIPTION
This PR removes the clear form button from the ExpenseForm component to simplify the user interface.

## Changes
- **Remove**  function
- **Remove** clear form button from the UI
- **Simplify** form layout by removing unnecessary button
- **Keep** form persistence functionality intact

## Rationale
The clear form button was rarely used and added unnecessary complexity to the form. Users can still:
- Submit the form to clear the amount field (keeping other fields)
- Use browser refresh to completely reset the form
- The form persistence feature still works for better UX

## UI Impact
- Cleaner, simpler form interface
- Single submit button instead of two buttons
- Reduced visual clutter